### PR TITLE
refactor (?): try to simplify puzzle initialization

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -32,6 +32,13 @@ runtimes:
     - python@3.12.0
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
+  definitions:
+    # I think we have to add pyproject.toml to direct_configs because the plugin doesn't define it
+    # https://github.com/trunk-io/plugins/blob/main/linters/pyright/plugin.yaml#L26
+    - name: pyright
+      direct_configs:
+        - pyproject.toml
+        - pyrightconfig.json
   disabled:
     - isort
     - bandit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,4 @@ select = [
 typeCheckingMode = "strict"
 pythonVersion = "3.12"
 ignore = ["src/examples/"]
+executionEnvironments = [{ root = "." }]

--- a/src/puzzle.py
+++ b/src/puzzle.py
@@ -51,13 +51,12 @@ class Puzzle:
         that's exactly the number of houses.
         """
 
-        self.elements = list(elements)
-        self.element_classes = list(element_types)
+        self.solution = solution
+        self.elements = list(solution.keys())
+        self.element_classes = list({type(e) for e in self.elements})
 
         self.size = len(self.elements) // len(self.element_classes)
         self.houses = tuple(range(1, self.size + 1))
-
-        self.solution = solution
 
         self.clues: set[Clue] = set()
         self.constraints = self._get_constraints()

--- a/src/puzzle.py
+++ b/src/puzzle.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Generator, Iterable, Mapping
+from collections.abc import Generator, Iterable, Mapping, Sequence
 from contextlib import contextmanager
 from random import shuffle
 from typing import Self
@@ -52,8 +52,8 @@ class Puzzle:
         """
 
         self.solution = solution
-        self.elements = list(solution.keys())
-        self.element_classes = list({type(e) for e in self.elements})
+        self.elements: Sequence[PuzzleElement] = list(solution.keys())
+        self.element_classes: Sequence[type[PuzzleElement]] = list({type(e) for e in self.elements})
 
         self.size = len(self.elements) // len(self.element_classes)
         self.houses = tuple(range(1, self.size + 1))


### PR DESCRIPTION
... but mostly this is to see what trunk does; it supposedly runs on PRs, so let's try that.

The actual functional effect of this change is that we take a step towards removing the redundancy of the Puzzle initialization. The solution exactly defines the puzzle elements & types of elements, so we don't need those as separate arguments

The Trunk CLI said that I introduced 74 new issues (?!), which ... huh? Let's just see what this does.
